### PR TITLE
Rewrite tests to use doubles for Monzo class

### DIFF
--- a/doubles/monzo.py
+++ b/doubles/monzo.py
@@ -1,0 +1,174 @@
+"""A replacement for monzo.monzo.Monzo for testing puropses
+"""
+from monzo.request import Request
+
+class Monzo(object):
+    """The stubbed out class representation of the Monzo client
+    """
+
+    def __init__(self, access_token):
+        pass
+
+    def whoami(self):
+        """Gives information about an access token.
+           (https://monzo.com/docs/#authenticating-requests)
+
+           :rtype: A stubbed Dictionary representation of the authentication status.
+        """
+        return {
+            "authenticated": True,
+            "client_id": "client_id",
+            "user_id": "user_id"
+        }
+
+    # def get_accounts(self):
+    #     """Get all accounts that belong to a user. (https://monzo.com/docs/#list-accounts)
+    #
+    #        :rtype: A Collection of accounts for a user.
+    #
+    #     """
+    #     url = "{0}/accounts".format(self.API_URL)
+    #     response = self.request.get(url, headers=self.headers)
+    #     return response
+    #
+    # def get_first_account(self):
+    #     """Gets the first account for a user.
+    #
+    #        :rtype: A Dictionary representation of the first account belonging to a user, if it exists.
+    #
+    #     """
+    #     accounts = self.get_accounts()
+    #     if len(accounts['accounts']) <= 0:
+    #         raise LookupError('There are no accounts associated with this user.')
+    #     return accounts['accounts'][0]
+    #
+    # def get_transactions(self, account_id):
+    #     """Get all transactions of a given account. (https://monzo.com/docs/#list-transactions)
+    #
+    #        :param account_id: The unique identifier for the account which the transactions belong to.
+    #        :rtype: A collection of transaction objects for specific user.
+    #     """
+    #     url = "{0}/transactions".format(self.API_URL)
+    #     params = {'expand[]': 'merchant', 'account_id': account_id}
+    #     response = self.request.get(url, headers=self.headers, params=params)
+    #     return response
+    #
+    # def get_balance(self, account_id):
+    #     """Gets the balance of a given account. (https://monzo.com/docs/#read-balance)
+    #
+    #        :param account_id: The unique identifier for the account which the balance belong to.
+    #        :rtype: Dictionary representation of the current account balance.
+    #
+    #     """
+    #     url = "{0}/balance".format(self.API_URL)
+    #     params = {'account_id': account_id}
+    #     response = self.request.get(url, headers=self.headers, params=params)
+    #     return response
+    #
+    # def get_webhooks(self, account_id):
+    #     """Gets the webhooks of a given account. (https://monzo.com/docs/#list-webhooks)
+    #
+    #        :param account_id: The unique identifier for the account which the webhooks belong to.
+    #        :rtype: A collection of webhooks that belong to an account.
+    #
+    #     """
+    #     url = "{0}/webhooks".format(self.API_URL)
+    #     params = {'account_id': account_id}
+    #     response = self.request.get(url, headers=self.headers, params=params)
+    #     return response
+    #
+    # def get_first_webhook(self, account_id):
+    #     """Gets the first webhook of a given account.
+    #
+    #        :param account_id: The unique identifier for the account which the first webhook belong to.
+    #        :rtype: A Dictionary representation of the first webhook belonging to an account, if it exists.
+    #     """
+    #     webhooks = self.get_webhooks(account_id)
+    #     if len(webhooks['webhooks']) <= 0:
+    #         raise LookupError('There are no webhooks associated with the account.')
+    #     return webhooks['webhooks'][0]
+    #
+    # def delete_webhook(self, webhook_id):
+    #     """Deletes the a specified webhook. (https://monzo.com/docs/#deleting-a-webhook)
+    #
+    #        :param webhook_id: The unique identifier for the webhook to delete.
+    #        :rtype: An empty Dictionary, if the deletion was successful.
+    #     """
+    #     url = "{0}/webhooks/{1}".format(self.API_URL, webhook_id)
+    #     response = self.request.delete(url, headers=self.headers)
+    #     return response
+    #
+    # def delete_all_webhooks(self):
+    #     """Removes all webhooks associated with the first account, if it exists.
+    #
+    #        :rtype: None
+    #     """
+    #     first_account = self.get_first_account()
+    #     account_id = first_account['id']
+    #     webhooks = self.get_webhooks(account_id)
+    #     for webhook in webhooks['webhooks']:
+    #         self.delete_webhook(webhook['id'])
+    #
+    # def register_webhook(self, webhook_url, account_id):
+    #     """Registers a webhook. (https://monzo.com/docs/#registering-a-webhook)
+    #
+    #        :param webhook_url: The webhook url to register.
+    #        :param account_id: The unique identifier for the account to register the webhook.
+    #
+    #        :rtype: Registers a webhook to an account.
+    #     """
+    #     url = "{0}/webhooks".format(self.API_URL)
+    #     response = self.request.post(url, headers=self.headers, data={'account_id': account_id, 'url': webhook_url})
+    #
+    # def register_attachment(self, transaction_id, file_url, file_type):
+    #     """Attaches an image to a transaction. (https://monzo.com/docs/#register-attachment)
+    #
+    #        :param transaction_id: The unique identifier for the transaction to register the attachment to.
+    #        :param file_url: The url of the file to attach.
+    #        :param transaction_id: The type of the file specified in file_url
+    #
+    #        :rtype: Dictionary representation of the attachment that was just registered.
+    #     """
+    #     url = "{0}/attachment/register".format(self.API_URL)
+    #     response = self.request.post(url,
+    #                                 headers=self.headers,
+    #                                 data={'external_id': transaction_id,
+    #                                       'file_url': file_url,
+    #                                       'file_type': file_type})
+    #     return response
+    #
+    # def deregister_attachment(self, attachment_id):
+    #     """Removed a previously attached image from a transaction. (https://monzo.com/docs/#deregister-attachment)
+    #
+    #         :param transaction_id: The unique identifier for the attachment to deregister.
+    #         :rtype: An empty Dictionary, if the deregistration was successful.
+    #     """
+    #     url = "{0}/attachment/deregister".format(self.API_URL)
+    #     response = self.request.post(url, headers=self.headers, data={'id': attachment_id})
+    #     return response
+    #
+    #
+    # def create_feed_item(self, account_id, feed_type, url, params):
+    #     """Creates a feed item. (https://monzo.com/docs/#create-feed-item)
+    #
+    #         :param account_id: The unique identifier for the account to create the feed item for.
+    #         :param feed_type: The type of feed item (currently only `basic` is supported).
+    #         :param url: The url to open if a feed item is tapped
+    #         :param params: A map of parameters which vary based on type
+    #
+    #         :rtype: An empty Dictionary, if the feed item creation was successful.
+    #     """
+    #     url = "{0}/feed".format(self.API_URL)
+    #     data = {
+    #         'account_id': account_id,
+    #         'type': feed_type,
+    #         'url': url,
+    #         "params[title]": params['title'],
+    #         "params[image_url]": params['image_url'],
+    #         "params[body]": params['body']
+    #     }
+    #     response = self.request.post(url,
+    #                                  headers=self.headers,
+    #                                  data=data
+    #                                  )
+    #     return response

--- a/doubles/monzo.py
+++ b/doubles/monzo.py
@@ -1,6 +1,5 @@
 """A replacement for monzo.monzo.Monzo for testing puropses
 """
-from monzo.request import Request
 
 class Monzo(object):
     """The stubbed out class representation of the Monzo client
@@ -13,7 +12,7 @@ class Monzo(object):
         """Gives information about an access token.
            (https://monzo.com/docs/#authenticating-requests)
 
-           :rtype: A stubbed Dictionary representation of the authentication status.
+           :rtype: A stubbed dictionary representation of the authentication status.
         """
         return {
             "authenticated": True,
@@ -21,154 +20,186 @@ class Monzo(object):
             "user_id": "user_id"
         }
 
-    # def get_accounts(self):
-    #     """Get all accounts that belong to a user. (https://monzo.com/docs/#list-accounts)
-    #
-    #        :rtype: A Collection of accounts for a user.
-    #
-    #     """
-    #     url = "{0}/accounts".format(self.API_URL)
-    #     response = self.request.get(url, headers=self.headers)
-    #     return response
-    #
-    # def get_first_account(self):
-    #     """Gets the first account for a user.
-    #
-    #        :rtype: A Dictionary representation of the first account belonging to a user, if it exists.
-    #
-    #     """
-    #     accounts = self.get_accounts()
-    #     if len(accounts['accounts']) <= 0:
-    #         raise LookupError('There are no accounts associated with this user.')
-    #     return accounts['accounts'][0]
-    #
-    # def get_transactions(self, account_id):
-    #     """Get all transactions of a given account. (https://monzo.com/docs/#list-transactions)
-    #
-    #        :param account_id: The unique identifier for the account which the transactions belong to.
-    #        :rtype: A collection of transaction objects for specific user.
-    #     """
-    #     url = "{0}/transactions".format(self.API_URL)
-    #     params = {'expand[]': 'merchant', 'account_id': account_id}
-    #     response = self.request.get(url, headers=self.headers, params=params)
-    #     return response
-    #
-    # def get_balance(self, account_id):
-    #     """Gets the balance of a given account. (https://monzo.com/docs/#read-balance)
-    #
-    #        :param account_id: The unique identifier for the account which the balance belong to.
-    #        :rtype: Dictionary representation of the current account balance.
-    #
-    #     """
-    #     url = "{0}/balance".format(self.API_URL)
-    #     params = {'account_id': account_id}
-    #     response = self.request.get(url, headers=self.headers, params=params)
-    #     return response
-    #
-    # def get_webhooks(self, account_id):
-    #     """Gets the webhooks of a given account. (https://monzo.com/docs/#list-webhooks)
-    #
-    #        :param account_id: The unique identifier for the account which the webhooks belong to.
-    #        :rtype: A collection of webhooks that belong to an account.
-    #
-    #     """
-    #     url = "{0}/webhooks".format(self.API_URL)
-    #     params = {'account_id': account_id}
-    #     response = self.request.get(url, headers=self.headers, params=params)
-    #     return response
-    #
-    # def get_first_webhook(self, account_id):
-    #     """Gets the first webhook of a given account.
-    #
-    #        :param account_id: The unique identifier for the account which the first webhook belong to.
-    #        :rtype: A Dictionary representation of the first webhook belonging to an account, if it exists.
-    #     """
-    #     webhooks = self.get_webhooks(account_id)
-    #     if len(webhooks['webhooks']) <= 0:
-    #         raise LookupError('There are no webhooks associated with the account.')
-    #     return webhooks['webhooks'][0]
-    #
-    # def delete_webhook(self, webhook_id):
-    #     """Deletes the a specified webhook. (https://monzo.com/docs/#deleting-a-webhook)
-    #
-    #        :param webhook_id: The unique identifier for the webhook to delete.
-    #        :rtype: An empty Dictionary, if the deletion was successful.
-    #     """
-    #     url = "{0}/webhooks/{1}".format(self.API_URL, webhook_id)
-    #     response = self.request.delete(url, headers=self.headers)
-    #     return response
-    #
-    # def delete_all_webhooks(self):
-    #     """Removes all webhooks associated with the first account, if it exists.
-    #
-    #        :rtype: None
-    #     """
-    #     first_account = self.get_first_account()
-    #     account_id = first_account['id']
-    #     webhooks = self.get_webhooks(account_id)
-    #     for webhook in webhooks['webhooks']:
-    #         self.delete_webhook(webhook['id'])
-    #
-    # def register_webhook(self, webhook_url, account_id):
-    #     """Registers a webhook. (https://monzo.com/docs/#registering-a-webhook)
-    #
-    #        :param webhook_url: The webhook url to register.
-    #        :param account_id: The unique identifier for the account to register the webhook.
-    #
-    #        :rtype: Registers a webhook to an account.
-    #     """
-    #     url = "{0}/webhooks".format(self.API_URL)
-    #     response = self.request.post(url, headers=self.headers, data={'account_id': account_id, 'url': webhook_url})
-    #
-    # def register_attachment(self, transaction_id, file_url, file_type):
-    #     """Attaches an image to a transaction. (https://monzo.com/docs/#register-attachment)
-    #
-    #        :param transaction_id: The unique identifier for the transaction to register the attachment to.
-    #        :param file_url: The url of the file to attach.
-    #        :param transaction_id: The type of the file specified in file_url
-    #
-    #        :rtype: Dictionary representation of the attachment that was just registered.
-    #     """
-    #     url = "{0}/attachment/register".format(self.API_URL)
-    #     response = self.request.post(url,
-    #                                 headers=self.headers,
-    #                                 data={'external_id': transaction_id,
-    #                                       'file_url': file_url,
-    #                                       'file_type': file_type})
-    #     return response
-    #
-    # def deregister_attachment(self, attachment_id):
-    #     """Removed a previously attached image from a transaction. (https://monzo.com/docs/#deregister-attachment)
-    #
-    #         :param transaction_id: The unique identifier for the attachment to deregister.
-    #         :rtype: An empty Dictionary, if the deregistration was successful.
-    #     """
-    #     url = "{0}/attachment/deregister".format(self.API_URL)
-    #     response = self.request.post(url, headers=self.headers, data={'id': attachment_id})
-    #     return response
-    #
-    #
-    # def create_feed_item(self, account_id, feed_type, url, params):
-    #     """Creates a feed item. (https://monzo.com/docs/#create-feed-item)
-    #
-    #         :param account_id: The unique identifier for the account to create the feed item for.
-    #         :param feed_type: The type of feed item (currently only `basic` is supported).
-    #         :param url: The url to open if a feed item is tapped
-    #         :param params: A map of parameters which vary based on type
-    #
-    #         :rtype: An empty Dictionary, if the feed item creation was successful.
-    #     """
-    #     url = "{0}/feed".format(self.API_URL)
-    #     data = {
-    #         'account_id': account_id,
-    #         'type': feed_type,
-    #         'url': url,
-    #         "params[title]": params['title'],
-    #         "params[image_url]": params['image_url'],
-    #         "params[body]": params['body']
-    #     }
-    #     response = self.request.post(url,
-    #                                  headers=self.headers,
-    #                                  data=data
-    #                                  )
-    #     return response
+    def get_accounts(self):
+        """Get all accounts that belong to a user. (https://monzo.com/docs/#list-accounts)
+
+           :rtype: A stubbed collection of accounts for a user.
+
+        """
+        return {
+            "accounts": [
+                {
+                    "id": "acc_00009237aqC8c5umZmrRdh",
+                    "description": "Peter Pan's Account",
+                    "created": "2015-11-13T12:17:42Z"
+                }
+            ]
+        }
+
+    def get_first_account(self):
+        """Gets the first account for a user.
+
+           :rtype: A stubbed dictionary representation of the authentication status.
+
+        """
+        accounts = self.get_accounts()
+        return accounts['accounts'][0]
+
+    def get_transactions(self, account_id):
+        """Get all transactions of a given account. (https://monzo.com/docs/#list-transactions)
+
+           :param account_id: The unique identifier for the account which the transactions belong to.
+           :rtype: A stubbed collection of transaction objects for specific user.
+        """
+        return {
+            "transactions": [
+                {
+                    "account_balance": 13013,
+                    "amount": -510,
+                    "created": "2015-08-22T12:20:18Z",
+                    "currency": "GBP",
+                    "description": "THE DE BEAUVOIR DELI C LONDON        GBR",
+                    "id": "tx_00008zIcpb1TB4yeIFXMzx",
+                    "merchant": "merch_00008zIcpbAKe8shBxXUtl",
+                    "metadata": {},
+                    "notes": "Salmon sandwich 🍞",
+                    "is_load": False,
+                    "settled": "2015-08-23T12:20:18Z",
+                    "category": "eating_out"
+                },
+                {
+                    "account_balance": 12334,
+                    "amount": -679,
+                    "created": "2015-08-23T16:15:03Z",
+                    "currency": "GBP",
+                    "description": "VUE BSL LTD            ISLINGTON     GBR",
+                    "id": "tx_00008zL2INM3xZ41THuRF3",
+                    "merchant": "merch_00008z6uFVhVBcaZzSQwCX",
+                    "metadata": {},
+                    "notes": "",
+                    "is_load": False,
+                    "settled": "2015-08-24T16:15:03Z",
+                    "category": "eating_out"
+                },
+            ]
+        }
+
+    def get_balance(self, account_id):
+        """Gets the balance of a given account. (https://monzo.com/docs/#read-balance)
+
+           :param account_id: The unique identifier for the account which the balance belong to.
+           :rtype: A stubbed dictionary representation of the current account balance.
+
+        """
+        return {
+            "balance": 5000,
+            "currency": "GBP",
+            "spend_today": 0
+        }
+
+    def get_webhooks(self, account_id):
+        """Gets the webhooks of a given account. (https://monzo.com/docs/#list-webhooks)
+
+           :param account_id: The unique identifier for the account which the webhooks belong to.
+           :rtype: A stubbed collection of webhooks that belong to an account.
+
+        """
+        return {
+            "webhooks": [
+                {
+                    "account_id": "acc_000091yf79yMwNaZHhHGzp",
+                    "id": "webhook_000091yhhOmrXQaVZ1Irsv",
+                    "url": "http://example.com/callback"
+                },
+                {
+                    "account_id": "acc_000091yf79yMwNaZHhHGzp",
+                    "id": "webhook_000091yhhzvJSxLYGAceC9",
+                    "url": "http://example2.com/anothercallback"
+                }
+            ]
+        }
+
+    def get_first_webhook(self, account_id):
+        """Gets the first webhook of a given account.
+
+           :param account_id: The unique identifier for the account which the first webhook belong to.
+           :rtype: A stubbed dictionary representation of the first webhook belonging to an account, if it exists.
+        """
+        webhooks = self.get_webhooks(account_id)
+        return webhooks['webhooks'][0]
+
+    def delete_webhook(self, webhook_id):
+        """Deletes the a specified webhook. (https://monzo.com/docs/#deleting-a-webhook)
+
+           :param webhook_id: The unique identifier for the webhook to delete.
+           :rtype: An empty dictionary
+        """
+        return {}
+
+    def delete_all_webhooks(self):
+        """Removes all webhooks associated with the first account, if it exists.
+
+           :rtype: None
+        """
+        first_account = self.get_first_account()
+        account_id = first_account['id']
+        webhooks = self.get_webhooks(account_id)
+        for webhook in webhooks['webhooks']:
+            self.delete_webhook(webhook['id'])
+
+    def register_webhook(self, webhook_url, account_id):
+        """Registers a webhook. (https://monzo.com/docs/#registering-a-webhook)
+
+           :param webhook_url: The webhook url to register.
+           :param account_id: The unique identifier for the account to register the webhook.
+
+           :rtype: A stubbed dictionary representing a webhook 
+        """
+        return {
+            "webhook": {
+                "account_id": "account_id",
+                "id": "webhook_id",
+                "url": "http://example.com"
+            }
+        }
+
+    def register_attachment(self, transaction_id, file_url, file_type):
+        """Attaches an image to a transaction. (https://monzo.com/docs/#register-attachment)
+
+           :param transaction_id: The unique identifier for the transaction to register the attachment to.
+           :param file_url: The url of the file to attach.
+           :param transaction_id: The type of the file specified in file_url
+
+           :rtype: A stubbed dictionary representation of the attachment that was just registered.
+        """
+        return {
+            "attachment": {
+                "id": "attach_00009238aOAIvVqfb9LrZh",
+                "user_id": "user_00009238aMBIIrS5Rdncq9",
+                "external_id": "tx_00008zIcpb1TB4yeIFXMzx",
+                "file_url": "https://s3-eu-west-1.amazonaws.com/mondo-image-uploads/user_00009237hliZellUicKuG1/LcCu4ogv1xW28OCcvOTL-foo.png",
+                "file_type": "image/png",
+                "created": "2015-11-12T18:37:02Z"
+            }
+        }
+
+    def deregister_attachment(self, attachment_id):
+        """Removed a previously attached image from a transaction. (https://monzo.com/docs/#deregister-attachment)
+
+            :param transaction_id: The unique identifier for the attachment to deregister.
+            :rtype: An empty Dictionary, if the deregistration was successful.
+        """
+        return {}
+
+
+    def create_feed_item(self, account_id, feed_type, url, params):
+        """Creates a feed item. (https://monzo.com/docs/#create-feed-item)
+
+            :param account_id: The unique identifier for the account to create the feed item for.
+            :param feed_type: The type of feed item (currently only `basic` is supported).
+            :param url: The url to open if a feed item is tapped
+            :param params: A map of parameters which vary based on type
+
+            :rtype: An empty Dictionary, if the feed item creation was successful.
+        """
+        return {}

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -6,70 +6,62 @@ class TestApiEndpoints:
     def client(self):
         return Monzo('stubbed')
 
-    # def test_whoami(self, client):
-    #     whoami = client.whoami()
-    #     assert whoami['authenticated']
-    #
-    # def test_get_accounts(self, client):
-    #     accounts = client.get_accounts()
-    #     assert accounts['accounts'] is not None
-    #
-    # def test_get_transactions(self, client):
-    #     account_id = client.get_first_account()['id']
-    #     transactions = client.get_transactions(account_id)
-    #     assert transactions['transactions'] is not None
-    #
-    # def test_get_balance(self, client):
-    #     account_id = client.get_first_account()['id']
-    #     balance = client.get_balance(account_id)
-    #     assert balance['balance'] is not None
-    #
-    # def test_get_webhooks(self, client):
-    #     account_id = client.get_first_account()['id']
-    #     webhooks = client.get_webhooks(account_id)
-    #     assert webhooks['webhooks'] is not None
-    #
-    # def test_delete_webhook(self, client):
-    #     account_id = client.get_first_account()['id']
-    #     client.register_webhook(webhook_url='https://google.co.uk', account_id=account_id)
-    #     webhooks = client.get_webhooks(account_id)
-    #     webhook_count = len(webhooks['webhooks'])
-    #     webhook_id = client.get_first_webhook(account_id)['id']
-    #     client.delete_webhook(webhook_id)
-    #     new_webhooks = client.get_webhooks(account_id)
-    #     new_webhooks_count = len(new_webhooks['webhooks'])
-    #     assert new_webhooks_count == webhook_count - 1
-    #     client.delete_all_webhooks()
-    #
-    # def test_register_webhook(self, client):
-    #     account_id = client.get_first_account()['id']
-    #     client.register_webhook(webhook_url='https://google.co.uk', account_id=account_id)
-    #     webhooks = client.get_webhooks(account_id)
-    #     webhook_in_webhooks = [w for w in webhooks['webhooks'] if w['url'] == 'https://google.co.uk']
-    #     assert len(webhook_in_webhooks) > 0
-    #     client.delete_all_webhooks()
-    #
-    #
-    # def test_register_and_remove_attachment(self, client):
-    #     account_id = client.get_first_account()['id']
-    #     transactions = client.get_transactions(account_id)
-    #     first_transaction_id = transactions['transactions'][0]['id']
-    #     image_attachment = client.register_attachment(transaction_id=first_transaction_id,
-    #                                        file_url='http://www.nyan.cat/cats/original.gif',
-    #                                        file_type='image/gif')
-    #     attachment_id = image_attachment['attachment']['id']
-    #     assert attachment_id is not None
-    #     deregistered_attachment_response = client.deregister_attachment(attachment_id)
-    #     assert deregistered_attachment_response is not None
-    #
-    #
-    # def test_create_feed_item(self, client):
-    #     account_id = client.get_first_account()['id']
-    #     params = {'title': 'Python Testing :D',
-    #               'body': 'Is this real life?',
-    #               'image_url': 'http://www.nyan.cat/cats/original.gif'}
-    #     feed_item = client.create_feed_item(account_id=account_id,
-    #                                         feed_type='basic',
-    #                                         url='http://www.nyan.cat/',
-    #                                         params=params)
-    #     assert feed_item is not None
+    def test_whoami(self, client):
+        whoami = client.whoami()
+        assert whoami['authenticated']
+
+    def test_get_accounts(self, client):
+        accounts = client.get_accounts()
+        assert accounts['accounts'] is not None
+
+    def test_get_transactions(self, client):
+        account_id = client.get_first_account()['id']
+        transactions = client.get_transactions(account_id)
+        assert transactions['transactions'] is not None
+
+    def test_get_balance(self, client):
+        account_id = client.get_first_account()['id']
+        balance = client.get_balance(account_id)
+        assert balance['balance'] is not None
+
+    def test_get_webhooks(self, client):
+        account_id = client.get_first_account()['id']
+        webhooks = client.get_webhooks(account_id)
+        assert webhooks['webhooks'] is not None
+
+    def test_delete_webhook(self, client):
+        account_id = client.get_first_account()['id']
+        client.register_webhook(webhook_url='https://google.co.uk', account_id=account_id)
+        webhook_id = client.get_first_webhook(account_id)['id']
+        assert client.delete_webhook(webhook_id) == {}
+
+    def test_register_webhook(self, client):
+        account_id = client.get_first_account()['id']
+        client.register_webhook(webhook_url='https://google.co.uk', account_id=account_id)
+        webhooks = client.get_webhooks(account_id)
+        assert len(webhooks) > 0
+
+
+    def test_register_and_remove_attachment(self, client):
+        account_id = client.get_first_account()['id']
+        transactions = client.get_transactions(account_id)
+        first_transaction_id = transactions['transactions'][0]['id']
+        image_attachment = client.register_attachment(transaction_id=first_transaction_id,
+                                           file_url='does not matter',
+                                           file_type='does not matter')
+        attachment_id = image_attachment['attachment']['id']
+        assert attachment_id is not None
+        deregistered_attachment_response = client.deregister_attachment(attachment_id)
+        assert deregistered_attachment_response is not None
+
+
+    def test_create_feed_item(self, client):
+        account_id = client.get_first_account()['id']
+        params = {'title': 'does not matter',
+                  'body': 'does not matter',
+                  'image_url': 'does not matter'}
+        feed_item = client.create_feed_item(account_id=account_id,
+                                            feed_type='blah',
+                                            url='blah',
+                                            params=params)
+        assert feed_item is not None

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -1,76 +1,75 @@
-from monzo.monzo import Monzo
-from settings import get_environment_var
 import pytest
+from doubles.monzo import Monzo
 
 class TestApiEndpoints:
     @pytest.fixture
     def client(self):
-        return Monzo(get_environment_var('ACCESS_TOKEN'))
+        return Monzo('stubbed')
 
-    def test_whoami(self, client):
-        whoami = client.whoami()
-        assert whoami['authenticated']
-
-    def test_get_accounts(self, client):
-        accounts = client.get_accounts()
-        assert accounts['accounts'] is not None
-
-    def test_get_transactions(self, client):
-        account_id = client.get_first_account()['id']
-        transactions = client.get_transactions(account_id)
-        assert transactions['transactions'] is not None
-
-    def test_get_balance(self, client):
-        account_id = client.get_first_account()['id']
-        balance = client.get_balance(account_id)
-        assert balance['balance'] is not None
-
-    def test_get_webhooks(self, client):
-        account_id = client.get_first_account()['id']
-        webhooks = client.get_webhooks(account_id)
-        assert webhooks['webhooks'] is not None
-
-    def test_delete_webhook(self, client):
-        account_id = client.get_first_account()['id']
-        client.register_webhook(webhook_url='https://google.co.uk', account_id=account_id)
-        webhooks = client.get_webhooks(account_id)
-        webhook_count = len(webhooks['webhooks'])
-        webhook_id = client.get_first_webhook(account_id)['id']
-        client.delete_webhook(webhook_id)
-        new_webhooks = client.get_webhooks(account_id)
-        new_webhooks_count = len(new_webhooks['webhooks'])
-        assert new_webhooks_count == webhook_count - 1
-        client.delete_all_webhooks()
-
-    def test_register_webhook(self, client):
-        account_id = client.get_first_account()['id']
-        client.register_webhook(webhook_url='https://google.co.uk', account_id=account_id)
-        webhooks = client.get_webhooks(account_id)
-        webhook_in_webhooks = [w for w in webhooks['webhooks'] if w['url'] == 'https://google.co.uk']
-        assert len(webhook_in_webhooks) > 0
-        client.delete_all_webhooks()
-
-
-    def test_register_and_remove_attachment(self, client):
-        account_id = client.get_first_account()['id']
-        transactions = client.get_transactions(account_id)
-        first_transaction_id = transactions['transactions'][0]['id']
-        image_attachment = client.register_attachment(transaction_id=first_transaction_id,
-                                           file_url='http://www.nyan.cat/cats/original.gif',
-                                           file_type='image/gif')
-        attachment_id = image_attachment['attachment']['id']
-        assert attachment_id is not None
-        deregistered_attachment_response = client.deregister_attachment(attachment_id)
-        assert deregistered_attachment_response is not None
-
-
-    def test_create_feed_item(self, client):
-        account_id = client.get_first_account()['id']
-        params = {'title': 'Python Testing :D',
-                  'body': 'Is this real life?',
-                  'image_url': 'http://www.nyan.cat/cats/original.gif'}
-        feed_item = client.create_feed_item(account_id=account_id,
-                                            feed_type='basic',
-                                            url='http://www.nyan.cat/',
-                                            params=params)
-        assert feed_item is not None
+    # def test_whoami(self, client):
+    #     whoami = client.whoami()
+    #     assert whoami['authenticated']
+    #
+    # def test_get_accounts(self, client):
+    #     accounts = client.get_accounts()
+    #     assert accounts['accounts'] is not None
+    #
+    # def test_get_transactions(self, client):
+    #     account_id = client.get_first_account()['id']
+    #     transactions = client.get_transactions(account_id)
+    #     assert transactions['transactions'] is not None
+    #
+    # def test_get_balance(self, client):
+    #     account_id = client.get_first_account()['id']
+    #     balance = client.get_balance(account_id)
+    #     assert balance['balance'] is not None
+    #
+    # def test_get_webhooks(self, client):
+    #     account_id = client.get_first_account()['id']
+    #     webhooks = client.get_webhooks(account_id)
+    #     assert webhooks['webhooks'] is not None
+    #
+    # def test_delete_webhook(self, client):
+    #     account_id = client.get_first_account()['id']
+    #     client.register_webhook(webhook_url='https://google.co.uk', account_id=account_id)
+    #     webhooks = client.get_webhooks(account_id)
+    #     webhook_count = len(webhooks['webhooks'])
+    #     webhook_id = client.get_first_webhook(account_id)['id']
+    #     client.delete_webhook(webhook_id)
+    #     new_webhooks = client.get_webhooks(account_id)
+    #     new_webhooks_count = len(new_webhooks['webhooks'])
+    #     assert new_webhooks_count == webhook_count - 1
+    #     client.delete_all_webhooks()
+    #
+    # def test_register_webhook(self, client):
+    #     account_id = client.get_first_account()['id']
+    #     client.register_webhook(webhook_url='https://google.co.uk', account_id=account_id)
+    #     webhooks = client.get_webhooks(account_id)
+    #     webhook_in_webhooks = [w for w in webhooks['webhooks'] if w['url'] == 'https://google.co.uk']
+    #     assert len(webhook_in_webhooks) > 0
+    #     client.delete_all_webhooks()
+    #
+    #
+    # def test_register_and_remove_attachment(self, client):
+    #     account_id = client.get_first_account()['id']
+    #     transactions = client.get_transactions(account_id)
+    #     first_transaction_id = transactions['transactions'][0]['id']
+    #     image_attachment = client.register_attachment(transaction_id=first_transaction_id,
+    #                                        file_url='http://www.nyan.cat/cats/original.gif',
+    #                                        file_type='image/gif')
+    #     attachment_id = image_attachment['attachment']['id']
+    #     assert attachment_id is not None
+    #     deregistered_attachment_response = client.deregister_attachment(attachment_id)
+    #     assert deregistered_attachment_response is not None
+    #
+    #
+    # def test_create_feed_item(self, client):
+    #     account_id = client.get_first_account()['id']
+    #     params = {'title': 'Python Testing :D',
+    #               'body': 'Is this real life?',
+    #               'image_url': 'http://www.nyan.cat/cats/original.gif'}
+    #     feed_item = client.create_feed_item(account_id=account_id,
+    #                                         feed_type='basic',
+    #                                         url='http://www.nyan.cat/',
+    #                                         params=params)
+    #     assert feed_item is not None


### PR DESCRIPTION
I would like to rewrite the tests to use Test Doubles for the Monzo class, instead of making calls to the Monzo API.

The reasons are due to:

* Monzo currently doesn't have support for generating access tokens programmatically meaning that the current process involves manually changing API tokens every time a previous token expires. This is quite annoying.

* Due to network requests to the Monzo API happening every time a test is run, the tests are relatively slow.

* We only care about the signature of the response, not how the response is sent.

The potential pitfalls are:

* Every time the API endpoints change, we would have to manually change the mocks to match the change.

I believe the pros far outweigh the cons, at least as things currently stand. There aren't that many API endpoints, so keeping track of the changes and updating them with relatively small commits is a good tradeoff for faster tests.