### PR TITLE
Add the ability to get pot data to the api

### DIFF
--- a/doubles/monzo.py
+++ b/doubles/monzo.py
@@ -203,3 +203,24 @@ class Monzo(object):
             :rtype: An empty Dictionary, if the feed item creation was successful.
         """
         return {}
+
+    def get_pots(self):
+        """Get all pots that belong to a user.
+
+           :rtype: A stubbed collection of pots for a user.
+
+        """
+        return {
+            "pots": [
+                {
+                    "balance": 100,
+                    "deleted": False,
+                    "currency": "GBP",
+                    "id": "pot_1234567890123456789012",
+                    "created": "2017-12-25T21:13:45.045Z",
+                    "updated": "2018-02-11T18:38:56.624Z",
+                    "style": "purple_gradient",
+                    "name": "My Pot"
+                }
+            ]
+        }

--- a/monzo/monzo.py
+++ b/monzo/monzo.py
@@ -185,3 +185,13 @@ class Monzo(object):
                                      data=data
                                      )
         return response
+
+    def get_pots(self):
+        """Get all pots for a user.
+
+           :rtype: A collection of pots for a user.
+
+        """
+        url = "{0}/pots".format(self.API_URL)
+        response = self.request.get(url, headers=self.headers)
+        return response

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -25,7 +25,7 @@ class TestApiEndpoints:
         assert balance['balance'] is not None
 
     def test_get_pots(self, client):
-        pots = client.get_pots()
+        pots = client.get_pots()['pots']
         assert pots is not None
 
     def test_get_webhooks(self, client):

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -24,6 +24,10 @@ class TestApiEndpoints:
         balance = client.get_balance(account_id)
         assert balance['balance'] is not None
 
+    def test_get_pots(self, client):
+        pots = client.get_pots()
+        assert pots is not None
+
     def test_get_webhooks(self, client):
         account_id = client.get_first_account()['id']
         webhooks = client.get_webhooks(account_id)


### PR DESCRIPTION
I was using the api and noticed that there was no way of getting pots data and that the Monzo api supported getting pots data.
I added the ability to get pots data.
Added test and double for get pots in following commits.