### PR TITLE
Get first active account

### DIFF
--- a/monzo/monzo.py
+++ b/monzo/monzo.py
@@ -53,6 +53,9 @@ class Monzo(object):
         accounts = self.get_accounts()
         if len(accounts['accounts']) <= 0:
             raise LookupError('There are no accounts associated with this user.')
+        for i in accounts['accounts']:
+            if i['closed'] == False:
+                return i
         return accounts['accounts'][0]
 
     def get_transactions(self, account_id):


### PR DESCRIPTION
If a user has upgraded their Monzo to a full current account, then their first account will be their old, closed, pre-paid account. I thought this would be a good way to avoid confusion.