### PR TITLE
Include `.pytest_cache/` in `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# Testing
+.pytest_cache/


### PR DESCRIPTION
Running tests locally with `python -m pytest tests/` saves files to `.pytest_cache/` - these should not be committed to source control.