### PR TITLE
Get transaction

### DIFF
--- a/doubles/monzo.py
+++ b/doubles/monzo.py
@@ -298,3 +298,40 @@ class Monzo(object):
                 }
             ]
         }
+    
+    def get_transaction(self, transaction_id):
+        """Retrieve data for a specific transaction. (https://docs.monzo.com/#retrieve-transaction)
+           :param transaction_id: The unique identifier for the transaction for which data should be retrieved for.
+           :rtype: A dictionary containing the data for the specified transaction_id.
+        """
+        return {"transaction": {
+                "account_balance": 13013,
+                "amount": -510,
+                "created": "2015-08-22T12:20:18Z",
+                "currency": "GBP",
+                "description": "THE DE BEAUVOIR DELI C LONDON        GBR",
+                "id": "tx_00008zIcpb1TB4yeIFXMzx",
+                "merchant": {
+                    "address": {
+                        "address": "98 Southgate Road",
+                        "city": "London",
+                        "country": "GB",
+                        "latitude": 51.54151,
+                        "longitude": -0.08482400000002599,
+                        "postcode": "N1 3JD",
+                        "region": "Greater London"
+                    },
+                    "created": "2015-08-22T12:20:18Z",
+                    "group_id": "grp_00008zIcpbBOaAr7TTP3sv",
+                    "id": "merch_00008zIcpbAKe8shBxXUtl",
+                    "logo": "https://pbs.twimg.com/profile_images/527043602623389696/68_SgUWJ.jpeg",
+                    "emoji": "🍞",
+                    "name": "The De Beauvoir Deli Co.",
+                    "category": "eating_out"
+                },
+                "metadata": {},
+                "notes": "Salmon sandwich 🍞",
+                "is_load": false,
+                "settled": "2015-08-23T12:20:18Z"
+            }
+        }

--- a/doubles/monzo.py
+++ b/doubles/monzo.py
@@ -84,6 +84,43 @@ class Monzo(object):
             ]
         }
 
+    def get_transaction(self, transaction_id):
+        """Retrieve data for a specific transaction. (https://docs.monzo.com/#retrieve-transaction)
+           :param transaction_id: The unique identifier for the transaction for which data should be retrieved for.
+           :rtype: A dictionary containing the data for the specified transaction_id.
+        """
+        return {"transaction": {
+                "account_balance": 13013,
+                "amount": -510,
+                "created": "2015-08-22T12:20:18Z",
+                "currency": "GBP",
+                "description": "THE DE BEAUVOIR DELI C LONDON        GBR",
+                "id": "tx_00008zIcpb1TB4yeIFXMzx",
+                "merchant": {
+                    "address": {
+                        "address": "98 Southgate Road",
+                        "city": "London",
+                        "country": "GB",
+                        "latitude": 51.54151,
+                        "longitude": -0.08482400000002599,
+                        "postcode": "N1 3JD",
+                        "region": "Greater London"
+                    },
+                    "created": "2015-08-22T12:20:18Z",
+                    "group_id": "grp_00008zIcpbBOaAr7TTP3sv",
+                    "id": "merch_00008zIcpbAKe8shBxXUtl",
+                    "logo": "https://pbs.twimg.com/profile_images/527043602623389696/68_SgUWJ.jpeg",
+                    "emoji": "🍞",
+                    "name": "The De Beauvoir Deli Co.",
+                    "category": "eating_out"
+                },
+                "metadata": {},
+                "notes": "Salmon sandwich 🍞",
+                "is_load": False,
+                "settled": "2015-08-23T12:20:18Z"
+            }
+        }
+
     def get_balance(self, account_id):
         """Gets the balance of a given account. (https://monzo.com/docs/#read-balance)
 
@@ -297,41 +334,4 @@ class Monzo(object):
                     "category": "eating_out"
                 }
             ]
-        }
-    
-    def get_transaction(self, transaction_id):
-        """Retrieve data for a specific transaction. (https://docs.monzo.com/#retrieve-transaction)
-           :param transaction_id: The unique identifier for the transaction for which data should be retrieved for.
-           :rtype: A dictionary containing the data for the specified transaction_id.
-        """
-        return {"transaction": {
-                "account_balance": 13013,
-                "amount": -510,
-                "created": "2015-08-22T12:20:18Z",
-                "currency": "GBP",
-                "description": "THE DE BEAUVOIR DELI C LONDON        GBR",
-                "id": "tx_00008zIcpb1TB4yeIFXMzx",
-                "merchant": {
-                    "address": {
-                        "address": "98 Southgate Road",
-                        "city": "London",
-                        "country": "GB",
-                        "latitude": 51.54151,
-                        "longitude": -0.08482400000002599,
-                        "postcode": "N1 3JD",
-                        "region": "Greater London"
-                    },
-                    "created": "2015-08-22T12:20:18Z",
-                    "group_id": "grp_00008zIcpbBOaAr7TTP3sv",
-                    "id": "merch_00008zIcpbAKe8shBxXUtl",
-                    "logo": "https://pbs.twimg.com/profile_images/527043602623389696/68_SgUWJ.jpeg",
-                    "emoji": "🍞",
-                    "name": "The De Beauvoir Deli Co.",
-                    "category": "eating_out"
-                },
-                "metadata": {},
-                "notes": "Salmon sandwich 🍞",
-                "is_load": False,
-                "settled": "2015-08-23T12:20:18Z"
-            }
         }

--- a/doubles/monzo.py
+++ b/doubles/monzo.py
@@ -331,7 +331,7 @@ class Monzo(object):
                 },
                 "metadata": {},
                 "notes": "Salmon sandwich 🍞",
-                "is_load": false,
+                "is_load": False,
                 "settled": "2015-08-23T12:20:18Z"
             }
         }

--- a/monzo/monzo.py
+++ b/monzo/monzo.py
@@ -276,3 +276,12 @@ class Monzo(object):
            :rtype: The updated transaction object.
         """
         return self.update_transaction_metadata(transaction_id, 'notes', notes)
+    
+    def get_transaction(self, transaction_id):
+        """Retrieve data for a specific transaction. (https://docs.monzo.com/#retrieve-transaction)
+           :param transaction_id: The unique identifier for the transaction for which data should be retrieved for.
+           :rtype: A dictionary containing the data for the specified transaction_id.
+        """
+        url = "{0}/transactions/{1}".format(self.API_URL, transaction_id)
+        response = self.oauth_session.make_request(url)
+        return response

--- a/monzo/monzo.py
+++ b/monzo/monzo.py
@@ -85,6 +85,15 @@ class Monzo(object):
         params = {'expand[]': 'merchant', 'account_id': account_id}
         response = self.oauth_session.make_request(url, params=params)
         return response
+    
+    def get_transaction(self, transaction_id):
+        """Retrieve data for a specific transaction. (https://docs.monzo.com/#retrieve-transaction)
+           :param transaction_id: The unique identifier for the transaction for which data should be retrieved for.
+           :rtype: A dictionary containing the data for the specified transaction_id.
+        """
+        url = "{0}/transactions/{1}".format(self.API_URL, transaction_id)
+        response = self.oauth_session.make_request(url)
+        return response
 
     def get_balance(self, account_id):
         """Gets the balance of a given account. (https://monzo.com/docs/#read-balance)
@@ -276,12 +285,3 @@ class Monzo(object):
            :rtype: The updated transaction object.
         """
         return self.update_transaction_metadata(transaction_id, 'notes', notes)
-    
-    def get_transaction(self, transaction_id):
-        """Retrieve data for a specific transaction. (https://docs.monzo.com/#retrieve-transaction)
-           :param transaction_id: The unique identifier for the transaction for which data should be retrieved for.
-           :rtype: A dictionary containing the data for the specified transaction_id.
-        """
-        url = "{0}/transactions/{1}".format(self.API_URL, transaction_id)
-        response = self.oauth_session.make_request(url)
-        return response

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -90,3 +90,9 @@ class TestApiEndpoints:
                                            key = 'keyvalue',
                                            value='does not matter')
         assert updated_transaction is not None
+    
+    def test_get_transaction(self, client):
+        account_id = client.get_first_account()['id']
+        first_transaction_id = client.get_transactions(account_id)['transactions'][0]['id']
+        transaction_data = client.get_transaction(first_transaction_id)
+        assert transaction_data['transaction'] is not None

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -19,6 +19,12 @@ class TestApiEndpoints:
         transactions = client.get_transactions(account_id)
         assert transactions['transactions'] is not None
 
+    def test_get_transaction(self, client):
+        account_id = client.get_first_account()['id']
+        first_transaction_id = client.get_transactions(account_id)['transactions'][0]['id']
+        transaction_data = client.get_transaction(first_transaction_id)
+        assert transaction_data['transaction'] is not None
+
     def test_get_balance(self, client):
         account_id = client.get_first_account()['id']
         balance = client.get_balance(account_id)
@@ -90,9 +96,3 @@ class TestApiEndpoints:
                                            key = 'keyvalue',
                                            value='does not matter')
         assert updated_transaction is not None
-    
-    def test_get_transaction(self, client):
-        account_id = client.get_first_account()['id']
-        first_transaction_id = client.get_transactions(account_id)['transactions'][0]['id']
-        transaction_data = client.get_transaction(first_transaction_id)
-        assert transaction_data['transaction'] is not None


### PR DESCRIPTION
Great wrapper for the API by the way!

### Changes
As per request #18 I believe I have implemented this functionality. 

- Added get_transaction: Params: `transaction_id`. Returns: `dictionary object` containing the data for the requested transaction.
- Added get_transaction to doubles.
- Added test_get_transaction to tests.

I have tested the implementation myself with the following code in the test which worked successfully.
```python
from monzo.monzo import Monzo

client = Monzo('access_token_goes_here')
account_id = client.get_first_account()['id']
first_transaction_id = client.get_transactions(account_id)['transactions'][0]['id']
transaction_data = client.get_transaction(first_transaction_id)
print(transaction_data["transaction"])
```