### PR TITLE
Change delete_all_webhooks to take account id as argument

### DIFF
--- a/doubles/monzo.py
+++ b/doubles/monzo.py
@@ -173,13 +173,11 @@ class Monzo(object):
         """
         return {}
 
-    def delete_all_webhooks(self):
-        """Removes all webhooks associated with the first account, if it exists.
+    def delete_all_webhooks(self, account_id):
+        """Removes all webhooks associated with the specified account, if it exists.
 
            :rtype: None
         """
-        first_account = self.get_first_account()
-        account_id = first_account['id']
         webhooks = self.get_webhooks(account_id)
         for webhook in webhooks['webhooks']:
             self.delete_webhook(webhook['id'])

--- a/doubles/monzo.py
+++ b/doubles/monzo.py
@@ -176,6 +176,7 @@ class Monzo(object):
     def delete_all_webhooks(self, account_id):
         """Removes all webhooks associated with the specified account, if it exists.
 
+           :param account_id: The unique identifier for the account which all webhooks will be removed from.
            :rtype: None
         """
         webhooks = self.get_webhooks(account_id)

--- a/monzo/monzo.py
+++ b/monzo/monzo.py
@@ -165,13 +165,12 @@ class Monzo(object):
         response = self.oauth_session.make_request(url, method='DELETE')
         return response
 
-    def delete_all_webhooks(self):
-        """Removes all webhooks associated with the first account, if it exists.
+    def delete_all_webhooks(self, account_id):
+        """Removes all webhooks associated with the specified account, if it exists.
 
+           :param account_id: The unique identifier for the account which all webhooks will be removed from.
            :rtype: None
         """
-        first_account = self.get_first_account()
-        account_id = first_account['id']
         webhooks = self.get_webhooks(account_id)
         for webhook in webhooks['webhooks']:
             self.delete_webhook(webhook['id'])


### PR DESCRIPTION
For some reason we have `delete_all_webhooks` only being able to delete webhooks from the first account. This PR allows this to be done on any account.