### PR TITLE
Get investment data

### DIFF
--- a/doubles/monzo.py
+++ b/doubles/monzo.py
@@ -298,3 +298,14 @@ class Monzo(object):
                 }
             ]
         }
+    
+    def get_investment_data(self):
+        """Retrieve data from Monzo's API about the crowdfunding activities.
+        :rtype: A `dictionary` containing crowdfunding data.
+        """
+        return {'invested_amount': 199999955400,
+                'max_amount': 199999955400,
+                'max_shares': 2592520,
+                'share_price': 77145,
+                'shares_invested': 2592520,
+                'status': 'finished'}

--- a/monzo/monzo.py
+++ b/monzo/monzo.py
@@ -284,3 +284,6 @@ class Monzo(object):
         url = "{0}crowdfunding-investment/total".format(self.API_URL)
         response = self.oauth_session.make_request(url)
         return response
+        # or as no authentication is required for this endpoint.
+        # response = self.oauth_session.session.get(url).json()
+        # return response 

--- a/monzo/monzo.py
+++ b/monzo/monzo.py
@@ -276,3 +276,11 @@ class Monzo(object):
            :rtype: The updated transaction object.
         """
         return self.update_transaction_metadata(transaction_id, 'notes', notes)
+    
+    def get_investment_data(self):
+        """Retrieve data from Monzo's API about the crowdfunding activities.
+        :rtype: A `dictionary` containing crowdfunding data.
+        """
+        url = "{0}crowdfunding-investment/total".format(self.API_URL)
+        response = self.oauth_session.make_request(url)
+        return response

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -90,3 +90,7 @@ class TestApiEndpoints:
                                            key = 'keyvalue',
                                            value='does not matter')
         assert updated_transaction is not None
+
+    def test_get_investment_data(self, client):
+        crowdfunding_data = client.get_investment_data()
+        assert crowdfunding_data is not None


### PR DESCRIPTION
So was browsing the Monzo developer forums when I saw this [post](https://community.monzo.com/t/python-script-and-shortcut-to-view-the-amount-invested/53827/1) about the https://api.monzo.com/crowdfunding-investment/total endpoint.

I have made a quick PR adding this functionality 👍