### PR TITLE
Locking versions of libraries in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ setup(name='monzo',
       license='MIT',
       packages=['monzo'],
       install_requires=[
-          'requests',
-          'requests-oauthlib',
-          'python-dotenv'
+          'requests==2.20.0',
+          'requests-oauthlib==1.0.0',
+          'python-dotenv==0.5.1'
       ],
       )


### PR DESCRIPTION
Closes  #30

The authentication flow is broken for new users as it stands as requests_oauthlib have made breaking changes. I've set specific versions for the libraries specified in setup.py to ensure they are compatible.